### PR TITLE
Template payload attributes

### DIFF
--- a/datamechanics_airflow_plugin/operator.py
+++ b/datamechanics_airflow_plugin/operator.py
@@ -76,8 +76,8 @@ class DataMechanicsOperator(BaseOperator):
 
     def _build_payload(self):
         self.payload["jobName"] = self.job_name
-        if self._paylod_app_name is not None:
-            self.payload["appName"] = self._paylod_app_name
+        if self._payload_app_name is not None:
+            self.payload["appName"] = self._payload_app_name
         if self.config_template_name is not None:
             self.payload["configTemplateName"] = self.config_template_name
 

--- a/datamechanics_airflow_plugin/operator.py
+++ b/datamechanics_airflow_plugin/operator.py
@@ -54,7 +54,7 @@ class DataMechanicsOperator(BaseOperator):
         self.dm_retry_limit = dm_retry_limit
         self.dm_retry_delay = dm_retry_delay
         self.app_name = None  # will be set from the API response
-        self._paylod_app_name = app_name
+        self._payload_app_name = app_name
         self.job_name = job_name
         self.config_template_name = config_template_name
         self.config_overrides = config_overrides


### PR DESCRIPTION
# Overview:
Implements support for the following payload attributes to be accessible to airflow's template engine:
- `app_name`
- `job_name`
- `config_template_name`
- `config_overrides`

Airflow operators render templated arguments in between `__init__` and `execute`. To construct the payload dict using templated arguments, we have to build it post-templating (in `_build_payload`). 

## config_overrides:

This argument supports the following types: `str`, `dict`, template string, json file path. Template strings provide additional challenges covered in `_build_payload`: 
- airflow's xcom deserialization returns dicts using single quotes (json standard requires only double quotes)
- the templated value will be type str (example below)


```python
from datetime import datetime
from airflow import DAG
from airflow.models import Variable


def construct_overrides(num_cores: int, spot: bool, ti):
    num_cores = Variable.get(key="executor_num_cores", default_var=10)
    spot = Variable.get(key="executor_spot", default_var=True)
    config_overrides = {"executor": {"cores": num_cores, "spot": spot}}
    ti.xcom_push(key="config_overrides", value=json.dumps(config_overrides))


dag = DAG(
    dag_id="Spark_Job",
    schedule_interval="@daily",
    default_args={"start_date": datetime(2020, 1, 1)},
)

with dag:

    get_overrides = PythonOperator(
        task_id="get_overrides",
        python_callable=construct_overrides,
    )

    submit_spark_job = DataMechanicsOperator(
        task_id="submit_spark_job",
        config_overrides="{{ ti.xcom_pull(task_ids='get_overrides', key='config_overrides') }}",
    )

    get_overrides >> submit_spark_job
```