### PR TITLE
Operator: Spark Submit Callback

### DIFF
--- a/datamechanics_airflow_plugin/operator.py
+++ b/datamechanics_airflow_plugin/operator.py
@@ -99,7 +99,10 @@ class DataMechanicsOperator(BaseOperator):
         hook = self._get_hook()
         self.app_name = hook.submit_app(self.payload)
         if self.on_spark_submit_callback:
-            self.on_spark_submit_callback(hook, self.app_name, context)
+            try:
+                self.on_spark_submit_callback(hook, self.app_name, context)
+            except Exception as err:
+                self.log.exception(err)
         self._monitor_app(hook, context)
 
     def on_kill(self):


### PR DESCRIPTION
## DataMechanicsOperator.on_spark_submit_callback

This introduces an Operator callback which is executed immediately after the spark app is submitted. The function call is wrapped in a `try / except` to prevent callback failure propagating to the task instance and spark app. 

The approach is similar to Airflow's [BaseOperator callbacks](https://github.com/apache/airflow/blob/2.0.1/airflow/models/baseoperator.py#L232-L236). Additional parameters are included for ease of use.

**Function signature:**
- instantiated `DataMechanicsHook`
- app name
- task instance `context` dictionary

---

### Example usage

**Defining spark submit callback:**

```Python
from typing import Dict
from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
from datamechanics_airflow_plugin.hook import DataMechanicsHook


def spark_submit_slack_message(
    dm_hook: DataMechanicsHook, app_name: str, context: Dict
):
    app = dm_hook.get_app(app_name)
    app_url = dm_hook.get_app_page_url(app_name)

    # collect executor config information
    executor = app["config"]["executor"]
    num_cores = executor["cores"]
    memory = executor["memory"]
    instance_type = executor["instanceType"]

    # compose slack message
    message = [
        f"Running <{app_url}|{app_name}>",
        f"> *instanceType:* {instance_type}",
        f"> *cores:* {num_cores}",
        f"> *memory:* {memory}",
    ]

    # send slack message
    slack_hook = SlackWebhookHook(http_conn_id="slack", message="\n".join(message))
    slack_hook.execute()
```

**Usage in Operator:**

```Python
submit_spark_job = DataMechanicsOperator(
    task_id="submit_spark_job",
    job_name="spark_job_name",
    on_spark_submit_callback=spark_submit_slack_message,
)
```